### PR TITLE
Use temporary file and directory in tests for isolation

### DIFF
--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -12,16 +12,16 @@ my constant NQP-DIR-MODE    = 16877;
 
 # Temporary fixtures for test isolation
 my $tmpdir = $*TMPDIR.add("path-utils-test-" ~ now.Int);
-mkdir $tmpdir;
-$tmpdir.IO.chmod(POSIX-DIR-MODE);
+$tmpdir.mkdir;
+$tmpdir.chmod(POSIX-DIR-MODE);
 
 my $tmpfile = $tmpdir.add("sample.txt");
-spurt $tmpfile, "A" x FILE-SIZE;
-$tmpfile.IO.chmod(POSIX-FILE-MODE);
+$tmpfile.spurt("A" x FILE-SIZE);
+$tmpfile.chmod(POSIX-FILE-MODE);
 
 END {
-    unlink $tmpfile;
-    rmdir  $tmpdir;
+    .unlink with $tmpfile;
+    .rmdir  with $tmpdir;
 }
 
 my str $file = $tmpfile.absolute;

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -3,8 +3,29 @@ use path-utils;
 
 plan 57;
 
-my str $file = $?FILE;
-my str $dir  = $file.IO.parent.absolute;
+my constant POSIX-FILE-MODE = 0o644;
+my constant NQP-FILE-MODE   = 33188;
+my constant FILE-SIZE       = 4;
+
+my constant POSIX-DIR-MODE  = 0o755;
+my constant NQP-DIR-MODE    = 16877;
+
+# Temporary fixtures for test isolation
+my $tmpdir = $*TMPDIR.add("path-utils-test-" ~ now.Int);
+mkdir $tmpdir;
+$tmpdir.IO.chmod(POSIX-DIR-MODE);
+
+my $tmpfile = $tmpdir.add("sample.txt");
+spurt $tmpfile, "A" x FILE-SIZE;
+$tmpfile.IO.chmod(POSIX-FILE-MODE);
+
+END {
+    unlink $tmpfile;
+    rmdir  $tmpdir;
+}
+
+my str $file = $tmpfile.absolute;
+my str $dir  = $tmpdir.absolute;
 
 is-deeply path-exists($file), 1, "does $file exist";
 is-deeply path-exists($dir),  1, "does $dir exist";
@@ -59,15 +80,9 @@ if Rakudo::Internals.IS-WIN {
     pass "Windows mode checks unreliable" for ^18;
 }
 else {
-    # Some Linux distros use an umask that will create files and
-    # directories without world readability/executability.  So
-    # make sure the access rights are as to be expected by the tests.
-    $dir .IO.chmod(0o755);
-    $file.IO.chmod(0o644);
-
-    is-deeply path-mode($file),    33188, "is $file mode ok";
-    is-deeply path-mode($dir),     16877, "is $dir mode ok";
-    is-deeply path-filesize($file), 4328, "is $file filesize ok";
+    is-deeply path-mode($file),     NQP-FILE-MODE, "is $file mode ok";
+    is-deeply path-mode($dir),      NQP-DIR-MODE, "is $dir mode ok";
+    is-deeply path-filesize($file), FILE-SIZE, "is $file filesize ok";
 
      ok path-is-readable($file),   "is $file readable by user";
      ok path-is-writable($file),   "is $file writable by user";


### PR DESCRIPTION
I was experimenting with the tests and thought of a slightly different approach.

This PR proposes using a temporary directory and file in `$*TMPDIR` for the tests. The idea is:

- Keep tests isolated from the library’s source files.
- Set explicit POSIX permissions for clarity.
- Clean up automatically with an END block.
- All tests pass on my Arch Linux.

Totally fine if you prefer to keep the current fix — just sharing a possible alternative that worked for me.